### PR TITLE
FileSystem storage - with Rx support.

### DIFF
--- a/Sources/MustacheFoundation/Classes/Extensions/FileManager+Extensions.swift
+++ b/Sources/MustacheFoundation/Classes/Extensions/FileManager+Extensions.swift
@@ -1,0 +1,54 @@
+
+import Foundation
+
+public extension FileManager {
+
+    func decodeObject<T>(forKey key: String) -> T? where T: Decodable {
+        let url = self.url(forKey: key)
+        guard self.fileExists(atPath: url.path),
+              let saved = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        let loaded = try? decoder.decode([T].self, from: saved).first
+        return loaded
+    }
+    
+    func encode<T>(_ value: T?, forKey key: String) where T: Encodable {
+        let name = self.notificationName(key: key)
+        
+        let url = self.url(forKey: key)
+        let encoder = JSONEncoder()
+        guard let value, let encoded = try? encoder.encode([value]) else {
+            try? self.removeItem(at: url)
+            NotificationCenter.default.post(name: name, object: nil)
+            return
+        }
+        try? encoded.write(to: url, options: .atomic)
+        NotificationCenter.default.post(name: name, object: nil)
+    }
+    
+    func hasValue(forKey key: String) -> Bool {
+        let url = self.url(forKey: key)
+        return self.fileExists(atPath: url.path)
+    }
+    
+    // MARK: - Notification
+
+    private static let didChangeNotification = "MFileManagerDidChangeNotification"
+    
+    func notificationName(key: String) -> NSNotification.Name {
+        let rawValue = "\(FileManager.didChangeNotification)-\(key)"
+        let notificationName = NSNotification.Name(rawValue: rawValue)
+        return notificationName
+    }
+
+    // MARK: - File URL/path
+    
+    private func url(forKey key: String) -> URL {
+        return self.applicationSupportDirectoryURL.appendingPathComponent(key)
+    }
+    
+    private var applicationSupportDirectoryURL: URL {
+        return self.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    }
+    
+}

--- a/Sources/MustacheFoundation/Classes/Storage/FileSystem/FileSystem.swift
+++ b/Sources/MustacheFoundation/Classes/Storage/FileSystem/FileSystem.swift
@@ -1,0 +1,34 @@
+
+import Foundation
+
+@propertyWrapper
+open class FileSystem<Value: Codable> {
+    
+    private var key: String
+    private var defaultValue: Value
+    
+    public init(_ key: String, defaultValue: Value) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    open var wrappedValue: Value {
+        get { FileManager.default.decodeObject(forKey: key) ?? self.defaultValue }
+        set { FileManager.default.encode(newValue, forKey: key) }
+    }
+}
+
+@propertyWrapper
+open class FileSystemOptional<Value: Codable> {
+
+    private var key: String
+
+    public init(_ key: String) {
+        self.key = key
+    }
+
+    open var wrappedValue: Value? {
+        get { FileManager.default.decodeObject(forKey: key) }
+        set { FileManager.default.encode(newValue, forKey: key) }
+    }
+}

--- a/Sources/MustacheRxSwift/Foundation/FileManager+Rx.swift
+++ b/Sources/MustacheRxSwift/Foundation/FileManager+Rx.swift
@@ -1,0 +1,14 @@
+
+import Foundation
+import RxSwift
+
+public extension FileManager {
+
+    func observeCodable<T: Codable>(_ type: T.Type, _ keyPath: String) -> RxObservable<T?> {
+        let name = self.notificationName(key: keyPath)        
+        return NotificationCenter.default.rx.notification(name).map { [keyPath]_ -> T? in
+            return self.decodeObject(forKey: keyPath)
+        }
+    }
+
+}

--- a/Sources/MustacheRxSwift/Foundation/RxFileSystem.swift
+++ b/Sources/MustacheRxSwift/Foundation/RxFileSystem.swift
@@ -1,0 +1,45 @@
+
+import Foundation
+import RxSwift
+
+@propertyWrapper
+open class RxFileSystem<Value: Codable> {
+    
+    private var key: String
+    private var defaultValue: Value
+    
+    public init(_ key: String, defaultValue: Value) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    open var wrappedValue: Value {
+        get { FileManager.default.decodeObject(forKey: key) ?? self.defaultValue }
+        set { FileManager.default.encode(newValue, forKey: key) }
+    }
+    
+    open var projectedValue: RxObservable<Value> {
+        return FileManager.default.observeCodable(Value.self, self.key).unwrap().startWith(self.wrappedValue)
+    }
+    
+}
+
+@propertyWrapper
+open class RxFileSystemOptional<Value: Codable> {
+    
+    private var key: String
+    
+    public init(_ key: String) {
+        self.key = key
+    }
+    
+    open var wrappedValue: Value? {
+        get { FileManager.default.decodeObject(forKey: key) }
+        set { FileManager.default.encode(newValue, forKey: key) }
+    }
+    
+    open var projectedValue: RxObservable<Value?> {
+        return FileManager.default.observeCodable(Value.self, self.key).startWith(self.wrappedValue)
+    }
+    
+}


### PR DESCRIPTION
UserDefaults is not happy with storing a lot of data and/or large objects  (+4MB).
Amba fetches and stores 4 MB of Courses and 1 MB of News which makes the system misbehave.
This is a storage variant where each object is stored in a separate file in the ApplicationSupportDirectory.
As with our other storage options there is not much error handling or cleanup.